### PR TITLE
Switch to Ruby 4.0

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -23,7 +23,7 @@ RUN zypper --non-interactive install --no-recommends \
   git \
   hostname \
   which \
-  "rubygem(ruby:3.4.0:yast-rake)" \
+  "rubygem(ruby:4.0.0:yast-rake)" \
   osc \
   obs-service-format_spec_file \
   obs-service-source_validator \


### PR DESCRIPTION
## Problem

- Similar to https://github.com/yast/ci-ruby-container/pull/28
- The container does not build in OBS because Ruby has been upgraded to version 4.0
 
## Solution

- Switch to Ruby 4.0
